### PR TITLE
Fix hardcoded GOARCH

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -36,7 +36,7 @@ for p in linux darwin darwin-arm windows; do
     [[ $p == windows ]] && fn+=".exe"
 
     echo ":golang::$p: $fn"
-    GOARCH=amd64 GOOS=$p CGO_ENABLED=0 \
+    GOARCH=$arch GOOS=$p CGO_ENABLED=0 \
         go build -ldflags="$ld" -o "./build/$fn" || die "cant build"
 done
 


### PR DESCRIPTION
GOARCH was hardcoded to `amd64` for some reason, and ignoring the `$arch` directive.